### PR TITLE
Update students without changing teachers/tutors/students/schedule

### DIFF
--- a/src/main/kotlin/ro/cadeca/weasylearn/controllers/SubjectController.kt
+++ b/src/main/kotlin/ro/cadeca/weasylearn/controllers/SubjectController.kt
@@ -76,4 +76,11 @@ class SubjectController(
     fun removeStudent(@PathVariable id: Long, @RequestParam username: String) {
         subjectService.removeStudent(id, username)
     }
+
+    @PatchMapping
+    @RolesAllowed(ADMIN)
+    fun update(@RequestBody subject: SubjectSaveDTO) {
+        subjectService.updateSubjectNoStudentsOrScheduleOrTutors(subject)
+    }
+
 }


### PR DESCRIPTION
This was a required feature for the app, so that it's not necessary to carry the students/tutors/teachers/schedule when they are not needed